### PR TITLE
Rate limiter implementation

### DIFF
--- a/src/LoadTester/StampedeLoadTester/Models/CommandLineOptions/MasterVerb.cs
+++ b/src/LoadTester/StampedeLoadTester/Models/CommandLineOptions/MasterVerb.cs
@@ -34,8 +34,8 @@ public class MasterVerb
     [Option("duration", 'd', true, "Duracion de prueba en segundos.")]
     public int Duration {get; set;}
 
-    [Option("rateLimitDelay", 'r', false, "Delay intencional en microsegundos entre cada mensaje enviado. Actúa como lastre para controlar la tasa de envío y ralentizar la ejecución. Default: 0 (sin delay)")]
-    public int RateLimitDelay {get; set;} = 0;
+    [Option("rateLimit", 'r', false, "Límite de mensajes por segundo a enviar. Si se especifica, controla la tasa de envío. Ejemplo: -r 100 para 100 mensajes/segundo. Default: 0 (sin límite)")]
+    public int RateLimit { get; set; } = 0;
 
     [Flag("ResponsePreview", 'v', "Si está presente, imprime la previsualización de la respuesta de cada transacción")]
     public bool ResponsePreview { get; set; } = false;

--- a/src/LoadTester/StampedeLoadTester/Models/TransactionFile.cs
+++ b/src/LoadTester/StampedeLoadTester/Models/TransactionFile.cs
@@ -15,7 +15,7 @@ namespace StampedeLoadTester.Models
         public string OutputQueue { get; set; } = string.Empty;
 
         [JsonPropertyName("transacciones")]
-        public List<string> Transacciones { get; set; } = [];
+        public string[] Transacciones { get; set; } = [];
 
 
         /// <summary>

--- a/src/LoadTester/StampedeLoadTester/Program.cs
+++ b/src/LoadTester/StampedeLoadTester/Program.cs
@@ -15,9 +15,9 @@ using Tresvi.CommandParser.Attributtes.Keywords;
 
 namespace StampedeLoadTester
 {
-    //dotnet run -- -f "xxx" -s "192.168.0.31, 192.168.0.24" -p 8888 -m "192.168.0.31;1414;CHANNEL1;MQGD" -d 2 -i "BNA.XX1.RESPUESTA" -o "BNA.XX1.PEDIDO"
-    //dotnet run -- -f ".\TestFiles\" -m "10.6.248.10;1414;CHANNEL1;MQGD" -d 2 -i "BNA.CU1.RESPUESTA" -o "BNA.CU1.PEDIDO"
-    //dotnet run -- -f "xxx" -m "10.6.248.10;1414;CHANNEL1;MQGD" -d 2 -i "BNA.CU2.RESPUESTA" -o "BNA.CU2.PEDIDO"
+    //dotnet run -- -f ".\TestFiles\Desa\trx_0559_164users.json" -m "10.6.248.10;1414;CHANNEL1;MQGD" -d 2 
+    //dotnet run -- -f ".\TestFiles\Desa\trx_0559_164users.json" -s "192.168.0.31, 192.168.0.24" -p 8888 -m "192.168.0.31;1414;CHANNEL1;MQGD" -d 2 
+    //dotnet run -- -f ".\TestFiles\Desa\trx_0559_164users.json" -m "10.6.248.10;1414;CHANNEL1;MQGD" -d 2 
     //TODO: Cuando se alcanza a ver la cola de msjes de Respuesta vacios, dejar de intentar recuperar las respuestas, porque todos van a dar MQRC_NO_MSG_AVAILABLE eternamente
     //TODO: Evaluar si la funcion ClearQueue es necesaria, ya que siempre deberia vaciarlas
     //TODO: Implementar salida de trxs a archivos
@@ -56,7 +56,6 @@ namespace StampedeLoadTester
                 }
             };
         }
-
 
 
         static async Task Main(string[] args)
@@ -116,14 +115,13 @@ namespace StampedeLoadTester
                 if (masterVerb.MessageExpiration != 0 && masterVerb.MessageExpiration < 240)
                     throw new Exception($"El tiempo de expiración debe ser al menos 240 segundos o 0 (sin expiración). Valor ingresado: ({masterVerb.MessageExpiration})");
 
-                // Cargar el archivo JSON en la instancia de TransactionFile
-                transactionFile.Load(masterVerb.File!);
+                transactionFile.Load(masterVerb.File!);     // Cargar el archivo JSON en la instancia de TransactionFile
                 
                 // Usar las transacciones del JSON
-                if (transactionFile.Transacciones.Count == 0)
+                if (transactionFile.Transacciones.Length == 0)
                     throw new Exception($"El archivo JSON {masterVerb.File} debe contener al menos 1 transaccion");
                 
-                transacciones = transactionFile.Transacciones.ToArray();
+                transacciones = transactionFile.Transacciones;
 
                 ipSlaves = masterVerb.GetSlaves();
                 mqConnParams.LoadMqConnectionParams(masterVerb.MqConnection, transactionFile.OutputQueue, transactionFile.InputQueue);
@@ -163,7 +161,7 @@ namespace StampedeLoadTester
 
                 Console.Write("Vaciando cola de respuesta después del warmup...");
                 Thread.Sleep(2000);
-                testManager.VaciarCola(mqConnParams.OutputQueue);
+                testManager.VaciarCola(mqConnParams.InputQueue);
                 Console.WriteLine($": OK");
 
                 if (ipSlaves.Count != 0)
@@ -202,6 +200,8 @@ namespace StampedeLoadTester
             Console.ResetColor();
 
             // Detener el monitoreo inmediatamente después del test (antes de obtener resultados de slaves)
+            
+            /*
             Dictionary<int, int> profundidades = [];
             if (monitorProfCts != null && taskMonitor != null)
             {
@@ -212,9 +212,9 @@ namespace StampedeLoadTester
                 foreach (var kvp in profundidades)
                 {
                     TimeSpan tiempo = TimeSpan.FromMilliseconds(kvp.Key);
-                    //Console.WriteLine($"Tiempo: {tiempo.TotalSeconds:F2}s - Profundidad: {kvp.Value}");
+                    Console.WriteLine($"Tiempo: {tiempo.TotalSeconds:F2}s - Profundidad: {kvp.Value}");
                 }
-            }
+            }*/
 
             List<(int? result, string ipSlave)> resultados = await GetSlavesResultsAsync(remoteController, ipSlaves, masterVerb.SlavePort, masterVerb.SlaveTimeout);
             PrintResults(resultados, nroMensajesColocados);
@@ -349,6 +349,7 @@ namespace StampedeLoadTester
             }
             return allSlavesInitialized;
         }
+
 
         /// <summary>
         /// Ejecuta el warmup en todos los esclavos remotos
@@ -580,22 +581,23 @@ namespace StampedeLoadTester
             Console.ResetColor();
         }
 
-        private static void PrintQueueStatistics(List<(DateTime hora, int profundidad)> mediciones)
+
+        private static void PrintQueueStatistics(List<(DateTime hora, int profundidad)> medicionesProfundidad)
         {
-            if (mediciones == null || mediciones.Count < 4)
+            if (medicionesProfundidad == null || medicionesProfundidad.Count < 4)
             {
-                Console.BackgroundColor = ConsoleColor.Yellow;
+                Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("No hay suficientes mediciones para calcular estadísticas (se requieren al menos 4 mediciones).");
                 Console.ResetColor();
                 return;
             }
 
             Console.ForegroundColor = ConsoleColor.Cyan;
-            Console.WriteLine("\n================== ESTADÍSTICAS DE PROCESAMIENTO DE COLA ==================");
+            Console.WriteLine("\n============ ESTADÍSTICAS DE PROCESAMIENTO DE COLA ============");
             
             // Descartar primera y última medición - usar índices directamente sin LINQ
             int inicio = 1; // Empezar desde el segundo elemento
-            int fin = mediciones.Count - 2; // Terminar en el penúltimo elemento
+            int fin = medicionesProfundidad.Count - 2; // Terminar en el penúltimo elemento
             
             if (fin < inicio)
             {
@@ -609,8 +611,8 @@ namespace StampedeLoadTester
             
             for (int i = inicio; i <= fin - 1; i++)
             {
-                var medicionActual = mediciones[i];
-                var medicionSiguiente = mediciones[i + 1];
+                var medicionActual = medicionesProfundidad[i];
+                var medicionSiguiente = medicionesProfundidad[i + 1];
                 
                 int profundidadAnterior = medicionActual.profundidad;
                 int profundidadActual = medicionSiguiente.profundidad;

--- a/src/LoadTester/StampedeLoadTester/Program.cs
+++ b/src/LoadTester/StampedeLoadTester/Program.cs
@@ -107,8 +107,8 @@ namespace StampedeLoadTester
                 if (masterVerb.Duration < 0)
                     throw new Exception($"La duracion del ensayo no puede ser negativa. Valor: ({masterVerb.Duration})");
 
-                if (masterVerb.RateLimitDelay < 0)
-                    throw new Exception($"El delay de lastre no puede ser negativo. Valor: ({masterVerb.RateLimitDelay})");
+                if (masterVerb.RateLimit < 0)
+                    throw new Exception($"El límite de mensajes por segundo no puede ser negativo. Valor: ({masterVerb.RateLimit})");
 
                 if (masterVerb.ThreadNumber > Environment.ProcessorCount)
                     throw new Exception($"El nro de hilos ({masterVerb.ThreadNumber}) no puede ser mayor al nro de CPUs ({Environment.ProcessorCount})");
@@ -192,7 +192,7 @@ namespace StampedeLoadTester
             Console.ForegroundColor = ConsoleColor.Green;
             int numHilos = masterVerb.ThreadNumber;
             Console.WriteLine($"{DateTime.Now:HH:mm:ss.ff} - Ejecutando test de carga en el master a {numHilos} hilos, aguarde {masterVerb.Duration} segundos...");
-            (int nroMensajesColocados, bool colaLlena) = ExecuteWriteQueueTest(testManager, numHilos, masterVerb.Duration * 1000, masterVerb.RateLimitDelay);
+            (int nroMensajesColocados, bool colaLlena) = ExecuteWriteQueueTest(testManager, numHilos, masterVerb.Duration * 1000, masterVerb.RateLimit > 0 ? masterVerb.RateLimit : (int?)null);
             if (colaLlena) Console.WriteLine($"Se alcanzó la capacidad de la cola de entrada. Se detiene la inyección de mensajes");
             Console.ResetColor();
 
@@ -441,10 +441,10 @@ namespace StampedeLoadTester
         }
 
 
-        private static (int messageCounter, bool colaLlena) ExecuteWriteQueueTest(TestManager manager, int numHilos, int durationMs, int delayMicroseconds)
+        private static (int messageCounter, bool colaLlena) ExecuteWriteQueueTest(TestManager manager, int numHilos, int durationMs, int? rateLimit = null)
         {
             TimeSpan duracionEnsayo = TimeSpan.FromMilliseconds(durationMs);
-            return manager.EjecutarWriteQueueLoadTest(duracionEnsayo, numHilos, delayMicroseconds);
+            return manager.EjecutarWriteQueueLoadTest(duracionEnsayo, numHilos, rateLimit);
         }
 
 

--- a/src/LoadTester/StampedeLoadTester/Program.cs
+++ b/src/LoadTester/StampedeLoadTester/Program.cs
@@ -161,6 +161,11 @@ namespace StampedeLoadTester
                 testManager.EnviarMensajesPrueba();
                 Console.WriteLine(": OK");
 
+                Console.Write("Vaciando cola de respuesta después del warmup...");
+                Thread.Sleep(2000);
+                testManager.VaciarCola(mqConnParams.OutputQueue);
+                Console.WriteLine($": OK");
+
                 if (ipSlaves.Count != 0)
                 {
                     Console.WriteLine("\n\n***********Verificando acceso a instancias en modo slave***********\n");
@@ -185,7 +190,7 @@ namespace StampedeLoadTester
                 return;
             }
 
-            Console.WriteLine("Iniciando monitoreo de profundidad de la cola...");
+            Console.WriteLine("\nIniciando monitoreo de profundidad de la cola...");
             monitorProfCts = new CancellationTokenSource();
             taskMonitor = testManager.MonitorearProfundidadColaAsync(mqConnParams.OutputQueue, monitorProfCts.Token);
 
@@ -203,11 +208,11 @@ namespace StampedeLoadTester
                 monitorProfCts.Cancel();
                 profundidades = await taskMonitor;
                 Console.WriteLine($"Se realizaron {profundidades.Count} lecturas");
-                // Ejemplo de uso: convertir milisegundos a hora
+                
                 foreach (var kvp in profundidades)
                 {
                     TimeSpan tiempo = TimeSpan.FromMilliseconds(kvp.Key);
-                    Console.WriteLine($"Tiempo: {tiempo.TotalSeconds:F2}s - Profundidad: {kvp.Value}");
+                    //Console.WriteLine($"Tiempo: {tiempo.TotalSeconds:F2}s - Profundidad: {kvp.Value}");
                 }
             }
 
@@ -579,7 +584,9 @@ namespace StampedeLoadTester
         {
             if (mediciones == null || mediciones.Count < 4)
             {
+                Console.BackgroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("No hay suficientes mediciones para calcular estadísticas (se requieren al menos 4 mediciones).");
+                Console.ResetColor();
                 return;
             }
 

--- a/src/LoadTester/StampedeLoadTester/Services/RemoteControllerService.cs
+++ b/src/LoadTester/StampedeLoadTester/Services/RemoteControllerService.cs
@@ -159,7 +159,7 @@ namespace StampedeLoadTester.Services;
                         
                         /*************************************************/
                         TimeSpan duracionEnsayo = TimeSpan.FromMilliseconds(2000);
-                        (int messageCounter, bool colaLlena) = manager.EjecutarWriteQueueLoadTest(duracionEnsayo, 6, 0); // delayMicroseconds = 0 por defecto para slaves
+                        (int messageCounter, bool colaLlena) = manager.EjecutarWriteQueueLoadTest(duracionEnsayo, 6);
                         
                         if (colaLlena) Console.WriteLine($"Cola llena detectada. Deteniendo todos los hilos...");
                         Console.WriteLine($"FIN: Msjes colocados: {messageCounter}");

--- a/src/LoadTester/StampedeLoadTester/Services/SimpleRateLimiter.cs
+++ b/src/LoadTester/StampedeLoadTester/Services/SimpleRateLimiter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace StampedeLoadTester.Services;
+
+public sealed class SimpleRateLimiter
+{
+    private readonly int _limitPerSecond;
+    private readonly object _gate = new();
+    private long _windowStartTicks; // Stopwatch ticks
+    private int _countInWindow;
+
+    private static readonly double TickFrequency = Stopwatch.Frequency; // ticks por segundo
+
+    public SimpleRateLimiter(int limitPerSecond)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limitPerSecond);
+
+        _limitPerSecond = limitPerSecond;
+        _windowStartTicks = Stopwatch.GetTimestamp();
+        _countInWindow = 0;
+    }
+
+    public void Wait()
+    {
+        while (true)
+        {
+            int sleepMs;
+
+            lock (_gate)
+            {
+                var now = Stopwatch.GetTimestamp();
+                var elapsedTicks = now - _windowStartTicks;
+
+                // Reset "perezoso" de la ventana al cruzar 1 segundo
+                if (elapsedTicks >= (long)TickFrequency)
+                {
+                    _windowStartTicks = now;
+                    _countInWindow = 0;
+                    elapsedTicks = 0;
+                }
+
+                // ¿Hay cupo?
+                if (_countInWindow < _limitPerSecond)
+                {
+                    _countInWindow++;
+                    return; // permitido
+                }
+
+                // No hay cupo entonces calcular cuánto falta para que termine la ventana
+                var remainingTicks = (long)TickFrequency - elapsedTicks;
+                var remainingSec = remainingTicks / TickFrequency;
+
+                sleepMs = (int)Math.Ceiling(remainingSec * 1000.0);
+                if (sleepMs < 1) sleepMs = 1;
+            }
+
+            // Dormir FUERA del lock
+            Thread.Sleep(sleepMs);
+        }
+    }
+}

--- a/src/LoadTester/StampedeLoadTester/TestManager.cs
+++ b/src/LoadTester/StampedeLoadTester/TestManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using IBM.WMQ;
 using LoadTester.Plugins;
 using StampedeLoadTester.Models;
+using StampedeLoadTester.Services;
 
 namespace StampedeLoadTester;
 
@@ -86,8 +87,17 @@ internal sealed class TestManager : IDisposable
         return IbmMQPlugin.VaciarCola(_queueManagers[0]!, queueName);
     }
 
-    public (int messageCounter, bool colaLlena) EjecutarWriteQueueLoadTest(TimeSpan duracionEnsayo, int numHilos, int delayMicroseconds)
+    private SimpleRateLimiter? _limiter;
+
+
+    public (int messageCounter, bool colaLlena) EjecutarWriteQueueLoadTest(TimeSpan duracionEnsayo, int numHilos, int? rateLimit = null)
     {
+        // Inicializar el limiter si se especifica rateLimit
+        if (rateLimit.HasValue && rateLimit.Value > 0)
+            _limiter = new SimpleRateLimiter(rateLimit.Value);
+        else
+            _limiter = null;
+
         int messageCounter = 0;
         bool colaLlena = false;
         long tiempoLimiteTicks = (long)(duracionEnsayo.TotalSeconds * Stopwatch.Frequency);
@@ -102,14 +112,14 @@ internal sealed class TestManager : IDisposable
 
             while (!loopState.ShouldExitCurrentIteration && Stopwatch.GetTimestamp() < horaFin)
             {
-                DelayMicroseconds(delayMicroseconds);
-
                 string mensajeAEnviar = _transacciones[ObtenerIndiceSiguienteMensaje()];
 
                 DateTime putDateTime = default;
                 byte[] messageId = null!;
                 try
                 {
+                    // Usar rate limiter si existe
+                    if (_limiter != null) _limiter.Wait();
                     (putDateTime, messageId) = IbmMQPlugin.EnviarMensaje(queueActual, mensajeAEnviar, _messageExpirationSeconds);
                 }
                 catch (MQException mqe) when (mqe.ReasonCode == MQC.MQRC_Q_FULL)
@@ -140,14 +150,11 @@ internal sealed class TestManager : IDisposable
 
     static void DelayMicroseconds(int microseconds)
     {
-        long ticksObjetivo =
-            microseconds * (Stopwatch.Frequency / 1_000_000);
-
+        long ticksObjetivo = microseconds * (Stopwatch.Frequency / 1_000_000);
         long start = Stopwatch.GetTimestamp();
 
         while (Stopwatch.GetTimestamp() - start < ticksObjetivo)
-        {
-        }
+        { }
     }
 
 

--- a/src/LoadTester/StampedeLoadTester/TestManager.cs
+++ b/src/LoadTester/StampedeLoadTester/TestManager.cs
@@ -24,7 +24,7 @@ internal sealed class TestManager : IDisposable
     private readonly MQQueue?[] _outputQueues = new MQQueue?[4];
     private readonly string[] _transacciones;
     private readonly int _messageExpirationSeconds;
-
+    private SimpleRateLimiter? _limiter;
 
     public TestManager(string queueManagerName, string outputQueueName, List<Hashtable> connectionProperties, ref string[] transacciones, int messageExpirationSeconds = 0)
     {
@@ -86,8 +86,6 @@ internal sealed class TestManager : IDisposable
 
         return IbmMQPlugin.VaciarCola(_queueManagers[0]!, queueName);
     }
-
-    private SimpleRateLimiter? _limiter;
 
 
     public (int messageCounter, bool colaLlena) EjecutarWriteQueueLoadTest(TimeSpan duracionEnsayo, int numHilos, int? rateLimit = null)

--- a/src/LoadTester/StampedeLoadTester/TestManager.cs
+++ b/src/LoadTester/StampedeLoadTester/TestManager.cs
@@ -328,7 +328,7 @@ internal sealed class TestManager : IDisposable
     /// </summary>
     /// <param name="queueName">Nombre de la cola a verificar</param>
     /// <param name="timeoutMs">Timeout en milisegundos. Si es null, esperará indefinidamente. Valor por defecto: null</param>
-    /// <param name="pollingIntervalMs">Intervalo en milisegundos entre consultas de profundidad. Valor por defecto: 100ms</param>
+    /// <param name="pollingIntervalMs">Intervalo en milisegundos entre consultas de profundidad.</param>
     /// <returns>true si la cola se vació, false si se alcanzó el timeout</returns>
     public bool WaitForQueueEmptied(string queueName, out List<(DateTime, int)> measurements, int? timeoutMs = null, int pollingIntervalMs = 100)
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces configurable throughput control and aligns data model.
> 
> - Adds `SimpleRateLimiter` and integrates it into `TestManager.EjecutarWriteQueueLoadTest` (new optional `rateLimit`), replacing the previous microsecond delay approach
> - Updates CLI: replaces `-r/--rateLimitDelay` with `-r/--rateLimit` (messages/sec) and validates non-negative; plumbs through `Program` and slave `RemoteControllerService` START path
> - Changes `TransactionFile.Transacciones` from `List<string>` to `string[]` and adjusts usages
> - Minor UX tweaks: additional queue warmup drain, messaging/output adjustments, and queue stats method cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e32d5541220a9af48bbaca22ec8b6cefcbde1883. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->